### PR TITLE
Remove Event field from message

### DIFF
--- a/__tests__/utils.spec.js
+++ b/__tests__/utils.spec.js
@@ -52,16 +52,6 @@ describe('Utils', () => {
         });
       });
 
-      it('shows the event name', () => {
-        const attachments = buildSlackAttachments({ status: 'STARTED', color: 'good', github: GITHUB_PUSH_EVENT });
-
-        expect(attachments[0].fields.find(a => a.title === 'Event')).toEqual({
-          title: 'Event',
-          value: 'push',
-          short: true,
-        });
-      });
-
       it('links to the branch', () => {
         const attachments = buildSlackAttachments({ status: 'STARTED', color: 'good', github: GITHUB_PUSH_EVENT });
 
@@ -95,16 +85,6 @@ describe('Utils', () => {
         expect(attachments[0].fields.find(a => a.title === 'Action')).toEqual({
           title: 'Action',
           value: `<https://github.com/voxmedia/github-action-slack-notify-build/commit/xyz678/checks | CI>`,
-          short: true,
-        });
-      });
-
-      it('shows the event name', () => {
-        const attachments = buildSlackAttachments({ status: 'STARTED', color: 'good', github: GITHUB_PR_EVENT });
-
-        expect(attachments[0].fields.find(a => a.title === 'Event')).toEqual({
-          title: 'Event',
-          value: 'pull_request',
           short: true,
         });
       });

--- a/src/utils.js
+++ b/src/utils.js
@@ -36,11 +36,6 @@ function buildSlackAttachments({ status, color, github, message }) {
       },
       referenceLink,
       {
-        title: 'Event',
-        value: event,
-        short: true,
-      },
-      {
         title: 'Author',
         value: actor,
         short: true,


### PR DESCRIPTION
## Purpose
Remove **Event** field from message, as it is a duplicate info.

## Important Changes
No Event field will show on message anymore.
